### PR TITLE
BUGFIX/MEDIUM(keepalived): Ensure service is restarted properly

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,0 @@
----
-# handlers file for ansible-role-openio-keepalived
-
-- name: reload keepalived
-  service:
-    name: "{{ keepalived_service_name }}"
-    state: reloaded
-  when: not keepalived_provision_only
-...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,12 +23,14 @@
     owner: root
     group: root
     mode: 0644
-  notify: reload keepalived
+  register: set_keepalived_config
 
-- name: 'Start service'
+- name: 'Start service or reload changed config'
   service:
     name: "{{ keepalived_service_name }}"
-    state: started
+    state: reloaded
     enabled: true
-  when: not keepalived_provision_only
+  when:
+    - not keepalived_provision_only
+    - set_keepalived_config is changed
 ...


### PR DESCRIPTION
 ##### SUMMARY
It appears the service reload handler is not always run, so use a
registered variable on config file templating and a conditionnal task to
do the same as the handler.

Note: `service: state: reloaded` will start the service if it wasn't, it
is a documented stable ansible module behavior.

Fixes: https://openio.atlassian.net/browse/OS-330

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### SCOPE (skeleton only)
- SDS

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION