### PR TITLE
BUGFIX/MINOR(keepalived): Fix the use of tags `install` and `configure`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
   with_first_found:
     - "{{ ansible_distribution }}.yml"
     - "{{ ansible_os_family }}.yml"
+  tags:
+    - install
+    - configure
 
 - name: 'Install packages'
   package:
@@ -15,6 +18,7 @@
   until: install_packages is success
   retries: 5
   delay: 2
+  tags: install
 
 - name: 'Set configuration'
   template:
@@ -24,6 +28,7 @@
     group: root
     mode: 0644
   register: set_keepalived_config
+  tags: configure
 
 - name: 'Start service or reload changed config'
   service:
@@ -33,4 +38,5 @@
   when:
     - not keepalived_provision_only
     - set_keepalived_config is changed
+  tags: configure
 ...


### PR DESCRIPTION
 ##### SUMMARY

It can be useful to prepare images to run only the `install` tag and then only the` configure` tag

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION