### PR TITLE
BUMP(keepalived): CI - Set requirements.yml to `19.10`

### DIFF
--- a/docker-tests/requirements.yml
+++ b/docker-tests/requirements.yml
@@ -1,5 +1,5 @@
 ---
 - src: https://github.com/open-io/ansible-role-openio-haproxy
-  version: "19.04"
+  version: "19.10"
   name: haproxy
 ...


### PR DESCRIPTION
 ##### SUMMARY

In order to be able to test the roles in `19.10`, it is necessary to change the branches in this file.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION