### PR TITLE
CHANGE(keepalived): Add flag to force package upgrade

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,4 +32,5 @@ keepalived_vrrp_instances:
     track_interface:
       - "{{ openio_bind_interface }}"
 keepalived_provision_only: false
+keepalived_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 ...

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: 'Install packages'
   package:
     name: "{{ item }}"
-    state: present
+    state: "{{ 'latest' if keepalived_package_upgrade else 'present' }}"
   with_items: "{{ keepalived_packages }}"
   register: install_packages
   until: install_packages is success


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION