### PR TITLE
BUGFIX/MINOR(keepalived): Add compat with python3

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -14,13 +14,13 @@ vrrp_script check_haproxy {
   rise 2
 }
 
-{% for vrrpiname, vrrpiopts in keepalived_vrrp_instances.iteritems() %}
+{% for vrrpiname, vrrpiopts in keepalived_vrrp_instances.items() | list %}
 vrrp_instance {{ vrrpiname }} {
-  {% for key, value in vrrpiopts.iteritems() -%}
+  {% for key, value in vrrpiopts.items() | list -%}
   {{ key }}
     {%- if value is string %} {{ value }}
     {%- elif value is mapping %} {
-      {% for vk,vv in value.iteritems() -%}
+      {% for vk,vv in value.items() | list -%}
   {{ vk }} {{ vv }}
       {% endfor %}
 }


### PR DESCRIPTION
 ##### SUMMARY

Replace python 2 syntax by one compatible with python 2 and 3.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```
fatal: [node02]: FAILED! => changed=false
  msg: 'AnsibleUndefinedVariable: ''dict object'' has no attribute ''iteritems'''
[WARNING]: Failure using method (v2_runner_on_failed) in callback plugin
(<ansible.plugins.callback.ara_default.CallbackModule object at 0x7f59d4a0a9e8>): 'NoneType' object
is not subscriptable
```
https://docs.ansible.com/ansible/latest/user_guide/playbooks_python_version.html#dict-iteritems