### PR TITLE
BUGFIX/MINOR(keepalived): Fix keepalived configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   - sudo modprobe ip_vs

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,12 @@ keepalived_vrrp_instances:
     advert_int: "1"
     authentication:
       auth_type: PASS
-      auth_pass: "{{ openio_keepalived_password | d('KEEP_PASS') }}"
+      auth_pass: "{{ openio_keepalived_password | d('KEEPPASS') }}"
+    unicast_src_ip: "{{ openio_bind_address }}"
     unicast_peer: "{{ groups[keepalived_inventory_groupname] \
-      | map('extract', hostvars, ['openio_bind_address']) | list | d([]) }}"
+      | map('extract', hostvars, ['openio_bind_address']) \
+      | list | d([]) \
+      | difference([openio_bind_address]) }}"
     virtual_ipaddress:
       - "{{ openio_bind_virtual_address }}/{{ openio_bind_virtual_address_mask }} \
           dev {{ openio_bind_interface }} label {{ openio_bind_interface }}:1"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,8 +1,8 @@
 ---
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
+  author: Cedric DELGEHIER <cedric@openio.io>
+  description: install an keepalived
+  company: OpenIO
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
@@ -15,9 +15,9 @@ galaxy_info:
   # - GPLv3
   # - Apache
   # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
+  license: AGPLv3
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.9
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:
@@ -33,19 +33,16 @@ galaxy_info:
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
   #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
+  platforms:
+    - name: Ubuntu
+      versions:
+        - bionic
+    - name: EL
+      versions:
+        - 7
 
-  galaxy_tags: []
+  galaxy_tags:
+    - system
     # List tags for your role here, one per line. A tag is a keyword that describes
     # and categorizes the role. Users find roles by searching for tags. Be sure to
     # remove the '[]' above, if you add tags to this list.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,20 @@
   delay: 2
   tags: install
 
+- name: Verify AUTH password
+  assert:
+    that:
+      - password | length <= 8
+      - password is match("^[a-zA-Z0-9]+$")
+    fail_msg: "auth_pass must contains only alphanumeric characters and not exceed 8 characters"
+  with_items: "{{ keepalived_vrrp_instances.values() \
+       | flatten \
+       | selectattr('authentication', 'defined') | map(attribute='authentication') \
+       | selectattr('auth_pass', 'defined') | map(attribute='auth_pass') \
+       | list }}"
+  loop_control:
+    loop_var: password
+
 - name: 'Set configuration'
   template:
     src: "{{ keepalived_conf_template }}"

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,12 +3,14 @@ global_defs {
    notification_email {
      {{ keepalived_global_defs_notification_email }}
    }
+   script_user root root
+   enable_script_security
    notification_email_from {{ keepalived_global_defs_notification_email_from }}
    smtp_server {{ keepalived_global_defs_smtp_server }}
    smtp_connect_timeout {{ keepalived_global_defs_smtp_connect_timeout }}
 }
 vrrp_script check_haproxy {
-  script "pgrep haproxy"
+  script "/usr/bin/pgrep haproxy"
   interval 2
   fall 3
   rise 2


### PR DESCRIPTION
 ##### SUMMARY

* Check auh_pass to respect keepalived policy
* Use a full path for `pgrep`
* Remove the local ip from the peer list `unicast_peer` to avoid message like `Keepalived_vrrp[30281]: (VI_01) WARNING - equal priority advert received from remote host with our IP address`
* Add `script_user` paramater
* Add `enable_script_security` parameter

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-494