### PR TITLE
BUGFIX/MINOR(keepalived): Fix keepalived configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,12 @@ keepalived_vrrp_instances:
     advert_int: "1"
     authentication:
       auth_type: PASS
-      auth_pass: "{{ openio_keepalived_password | d('KEEP_PASS') }}"
+      auth_pass: "{{ openio_keepalived_password | d('KEEPPASS') }}"
+    unicast_src_ip: "{{ openio_bind_address }}"
     unicast_peer: "{{ groups[keepalived_inventory_groupname] \
-      | map('extract', hostvars, ['openio_bind_address']) | list | d([]) }}"
+      | map('extract', hostvars, ['openio_bind_address']) \
+      | list | d([]) \
+      | difference([openio_bind_address]) }}"
     virtual_ipaddress:
       - "{{ openio_bind_virtual_address }}/{{ openio_bind_virtual_address_mask }} \
           dev {{ openio_bind_interface }} label {{ openio_bind_interface }}:1"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,20 @@
   delay: 2
   tags: install
 
+- name: Verify AUTH password
+  assert:
+    that:
+      - password | length <= 8
+      - password is match("^[a-zA-Z0-9]+$")
+    fail_msg: "auth_pass must contains only alphanumeric characters and not exceed 8 characters"
+  with_items: "{{ keepalived_vrrp_instances.values() \
+       | flatten \
+       | selectattr('authentication', 'defined') | map(attribute='authentication') \
+       | selectattr('auth_pass', 'defined') | map(attribute='auth_pass') \
+       | list }}"
+  loop_control:
+    loop_var: password
+
 - name: 'Set configuration'
   template:
     src: "{{ keepalived_conf_template }}"

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -3,12 +3,14 @@ global_defs {
    notification_email {
      {{ keepalived_global_defs_notification_email }}
    }
+   script_user root root
+   enable_script_security
    notification_email_from {{ keepalived_global_defs_notification_email_from }}
    smtp_server {{ keepalived_global_defs_smtp_server }}
    smtp_connect_timeout {{ keepalived_global_defs_smtp_connect_timeout }}
 }
 vrrp_script check_haproxy {
-  script "pgrep haproxy"
+  script "/usr/bin/pgrep haproxy"
   interval 2
   fall 3
   rise 2


### PR DESCRIPTION
 ##### SUMMARY

* Check auh_pass to respect keepalived policy
* Use a full path for `pgrep`
* Remove the local ip from the peer list `unicast_peer` to avoid message like `Keepalived_vrrp[30281]: (VI_01) WARNING - equal priority advert received from remote host with our IP address`
* Add `script_user` paramater
* Add `enable_script_security` parameter

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-494