### PR TITLE
BUGFIX/MINOR(SDS): Check keepalived password on "Configure" step

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,7 @@
        | list }}"
   loop_control:
     loop_var: password
+  tags: configure
 
 - name: 'Set configuration'
   template:


### PR DESCRIPTION
 ##### SUMMARY

- As an OpenIO administrator,
  When executing a deployment with the tag "configure" excluded, 
  Then I do not want the password check to be run

 ##### IMPACT

- N.C.

 ##### ADDITIONAL INFORMATION

N.C.